### PR TITLE
Feature/klmr box support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Encoding: UTF-8
 Package: covr
 Title: Test Coverage for Packages
-Version: 3.6.0.9100
+Version: 3.6.0.9001
 Authors@R: c(
     person("Jim", "Hester", email = "james.f.hester@gmail.com", role = c("aut", "cre")),
     person("Willem", "Ligtenberg", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Encoding: UTF-8
 Package: covr
 Title: Test Coverage for Packages
-Version: 3.6.0.9000
+Version: 3.6.0.9100
 Authors@R: c(
     person("Jim", "Hester", email = "james.f.hester@gmail.com", role = c("aut", "cre")),
     person("Willem", "Ligtenberg", role = "ctb"),

--- a/R/box.R
+++ b/R/box.R
@@ -1,3 +1,17 @@
 replacements_box <- function(env) {
-
+  unlist(recursive = FALSE, eapply(env, all.names = TRUE,
+      function(obj) {
+       if (inherits(obj, "box$mod")) {
+         lapply(names(obj),
+            function(f_name) {
+              f <- get(f_name, obj)
+              if (inherits(f, "function")) {
+                replacement(f_name, env = obj, target_value = f)
+              }
+            }
+          )
+        }
+      }
+    )
+  )
 }

--- a/R/box.R
+++ b/R/box.R
@@ -1,0 +1,3 @@
+replacements_box <- function(env) {
+
+}

--- a/R/covr.R
+++ b/R/covr.R
@@ -93,6 +93,7 @@ trace_environment <- function(env) {
       replacements_S4(env),
       replacements_RC(env),
       replacements_R6(env),
+      replacements_box(env),
       lapply(ls(env, all.names = TRUE), replacement, env = env)))
 
   lapply(the$replacements, replace)

--- a/tests/testthat/Testbox/app/app.R
+++ b/tests/testthat/Testbox/app/app.R
@@ -1,0 +1,6 @@
+options(box.path = file.path(getwd()))
+rm(list = ls(box:::loaded_mods), envir = box:::loaded_mods)
+
+box::use(
+  app/modules/module
+)

--- a/tests/testthat/Testbox/app/modules/module.R
+++ b/tests/testthat/Testbox/app/modules/module.R
@@ -1,0 +1,10 @@
+#' an example function
+#'
+#' @export
+a <- function(x) {
+  if (x <= 1) {
+    1
+  } else {
+    2
+  }
+}

--- a/tests/testthat/Testbox/tests/testthat.R
+++ b/tests/testthat/Testbox/tests/testthat.R
@@ -1,0 +1,6 @@
+options(box.path = file.path(getwd()))
+rm(list = ls(box:::loaded_mods), envir = box:::loaded_mods)
+
+library(testthat)
+
+test_dir("tests/testthat")

--- a/tests/testthat/Testbox/tests/testthat/test-module.R
+++ b/tests/testthat/Testbox/tests/testthat/test-module.R
@@ -1,0 +1,15 @@
+box::use(
+  testthat[test_that, expect_equal]
+)
+
+box::use(
+  app/modules/module
+)
+
+test_that("regular function `a` works as expected", {
+  expect_equal(module$a(1), 1)
+  expect_equal(module$a(2), 2)
+  expect_equal(module$a(3), 2)
+  expect_equal(module$a(4), 2)
+  expect_equal(module$a(0), 1)
+})

--- a/tests/testthat/test-box.R
+++ b/tests/testthat/test-box.R
@@ -4,7 +4,7 @@ test_that("box module coverage is reported", {
   withr::with_dir("./Testbox", {
     cov <- as.data.frame(file_coverage(
         source_files = "app/app.R",
-        test_files = list.files("tests/testthat", full.name = TRUE)))
+        test_files = list.files("tests/testthat", full.names = TRUE)))
 
     expect_equal(cov$value, c(5, 2, 3))
     expect_equal(cov$first_line, c(5, 6, 8))

--- a/tests/testthat/test-box.R
+++ b/tests/testthat/test-box.R
@@ -1,7 +1,7 @@
 context("box")
 
 test_that("box module coverage is reported", {
-  withr::with_dir("tests/testthat/Testbox", {
+  withr::with_dir("./Testbox", {
     cov <- as.data.frame(file_coverage(
         source_files = "app/app.R",
         test_files = list.files("tests/testthat", full.name = TRUE)))

--- a/tests/testthat/test-box.R
+++ b/tests/testthat/test-box.R
@@ -1,0 +1,12 @@
+context("box")
+
+test_that("box module coverage is reported", {
+  withr::with_dir("tests/testthat/Testbox", {
+    cov <- as.data.frame(file_coverage(
+        source_files = "app/app.R",
+        test_files = list.files("tests/testthat", full.name = TRUE)))
+
+    expect_true("a" %in% cov$functions)
+  })
+
+})

--- a/tests/testthat/test-box.R
+++ b/tests/testthat/test-box.R
@@ -6,6 +6,9 @@ test_that("box module coverage is reported", {
         source_files = "app/app.R",
         test_files = list.files("tests/testthat", full.name = TRUE)))
 
+    expect_equal(cov$value, c(5, 2, 3))
+    expect_equal(cov$first_line, c(5, 6, 8))
+    expect_equal(cov$last_line, c(5, 6, 8))
     expect_true("a" %in% cov$functions)
   })
 


### PR DESCRIPTION
Issue #2 

Test coverage works with basic box module loading.

```
box::use(
  app/module
)
```

* Unit tests provided
* To use with a rhino app, `covr::file_coverage(source_files = "app/main.R", test_files = list.files("test/testthat", full.names = TRUE))`
* To get the GUI report, `covr::report(covr::file_coverage(source_files = "app/main.R", test_files = list.files("tests/testthat", full.names = TRUE)))`
