### PR TITLE
Add covr visibility into private box module functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Encoding: UTF-8
 Package: covr
 Title: Test Coverage for Packages
-Version: 3.6.0.9001
+Version: 3.6.0.9002
 Authors@R: c(
     person("Jim", "Hester", email = "james.f.hester@gmail.com", role = c("aut", "cre")),
     person("Willem", "Ligtenberg", role = "ctb"),

--- a/R/box.R
+++ b/R/box.R
@@ -2,9 +2,10 @@ replacements_box <- function(env) {
   unlist(recursive = FALSE, eapply(env, all.names = TRUE,
       function(obj) {
        if (inherits(obj, "box$mod")) {
-         lapply(names(obj),
+         obj_impl <- attr(obj, "namespace")
+         lapply(ls(obj_impl),
             function(f_name) {
-              f <- get(f_name, obj)
+              f <- get(f_name, obj_impl)
               if (inherits(f, "function")) {
                 replacement(f_name, env = obj, target_value = f)
               }

--- a/tests/testthat/Testbox/app/modules/module.R
+++ b/tests/testthat/Testbox/app/modules/module.R
@@ -8,3 +8,7 @@ a <- function(x) {
     2
   }
 }
+
+private_function <- function(x) {
+  x ^ 2
+}

--- a/tests/testthat/Testbox/tests/testthat/test-module.R
+++ b/tests/testthat/Testbox/tests/testthat/test-module.R
@@ -6,10 +6,18 @@ box::use(
   app/modules/module
 )
 
+impl <- attr(module, "namespace")
+
 test_that("regular function `a` works as expected", {
   expect_equal(module$a(1), 1)
   expect_equal(module$a(2), 2)
   expect_equal(module$a(3), 2)
   expect_equal(module$a(4), 2)
   expect_equal(module$a(0), 1)
+})
+
+test_that("private function works as expected", {
+  expect_equal(impl$private_function(2), 4)
+  expect_equal(impl$private_function(3), 9)
+  expect_equal(impl$private_function(4), 16)
 })

--- a/tests/testthat/test-box.R
+++ b/tests/testthat/test-box.R
@@ -1,15 +1,16 @@
 context("box")
 
 test_that("box module coverage is reported", {
-  withr::with_dir("./Testbox", {
+  withr::with_dir("Testbox", {
     cov <- as.data.frame(file_coverage(
         source_files = "app/app.R",
         test_files = list.files("tests/testthat", full.names = TRUE)))
 
-    expect_equal(cov$value, c(5, 2, 3))
-    expect_equal(cov$first_line, c(5, 6, 8))
-    expect_equal(cov$last_line, c(5, 6, 8))
+    expect_equal(cov$value, c(5, 2, 3, 3))
+    expect_equal(cov$first_line, c(5, 6, 8, 13))
+    expect_equal(cov$last_line, c(5, 6, 8, 13))
     expect_true("a" %in% cov$functions)
+    expect_true("private_function" %in% cov$functions)
   })
 
 })


### PR DESCRIPTION
Issue #4 

## Changes description

Add support for testing box module implementation as described in https://klmr.me/box/articles/testing.html#test-interfaces-not-implementation-details-1

```
box::use(
  app/module
)

impl <- attr(module, "namespace")

test_that('implementation detail X works', {
    expect_true(impl$this_works())
})
```

## How to test

* Unit tests provided
* To use with a rhino app, covr::file_coverage(source_files = "app/main.R", test_files = list.files("test/testthat", full.names = TRUE))
* To get the GUI report, covr::report(covr::file_coverage(source_files = "app/main.R", test_files = list.files("tests/testthat", full.names = TRUE)))

Screenshot showing `covr` counting a private function:

![Screen Shot 2023-01-20 at 1 28 08 PM](https://user-images.githubusercontent.com/1477968/213624480-0a3d4bcc-0a92-494c-9a40-acc861a49540.png)