### PR TITLE
Feature/r6 objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Encoding: UTF-8
 Package: covr
 Title: Test Coverage for Packages
-Version: 3.6.0.9002
+Version: 3.6.0.9003
 Authors@R: c(
     person("Jim", "Hester", email = "james.f.hester@gmail.com", role = c("aut", "cre")),
     person("Willem", "Ligtenberg", role = "ctb"),

--- a/R/box.R
+++ b/R/box.R
@@ -16,3 +16,37 @@ replacements_box <- function(env) {
     )
   )
 }
+
+replacements_box_r6 <- function(env) {
+  unlist(recursive = FALSE, eapply(env, all.names = TRUE,
+      function(obj) {
+        if (inherits(obj, "box$mod")) {
+          obj_impl <- attr(obj, "namespace")
+          unlist(recursive = FALSE, lapply(ls(obj_impl),
+              function(f_name) {
+                f <- get(f_name, obj_impl)
+                if (inherits(f, "R6ClassGenerator")) {
+                  unlist(recursive = FALSE, eapply(f, all.names = TRUE,
+                      function(o) {
+                        if (inherits(o, "list")) {
+                          lapply(names(o),
+                            function(m_name) {
+                              m <- get(m_name, o)
+                              if (inherits(m, "function")) {
+                                replacement(m_name, env = obj, target_value = m)
+                              }
+                            }
+                          )
+                        }
+                      }
+                    )
+                  )
+                }
+              }
+            )
+          )
+        }
+      }
+    )
+  )
+}

--- a/R/covr.R
+++ b/R/covr.R
@@ -94,6 +94,7 @@ trace_environment <- function(env) {
       replacements_RC(env),
       replacements_R6(env),
       replacements_box(env),
+      replacements_box_r6(env),
       lapply(ls(env, all.names = TRUE), replacement, env = env)))
 
   lapply(the$replacements, replace)

--- a/tests/testthat/Testbox/app/app.R
+++ b/tests/testthat/Testbox/app/app.R
@@ -2,5 +2,6 @@ options(box.path = file.path(getwd()))
 rm(list = ls(box:::loaded_mods), envir = box:::loaded_mods)
 
 box::use(
-  app/modules/module
+  app/modules/module,
+  app/modules/moduleR6
 )

--- a/tests/testthat/Testbox/app/modules/moduleR6.R
+++ b/tests/testthat/Testbox/app/modules/moduleR6.R
@@ -1,0 +1,11 @@
+#' @export
+TestR6 <- R6::R6Class("TestR6", # nolint
+                      public = list(
+                        show = function(x) {
+                          1 + 3
+                        },
+                        print2 = function(x) {
+                          1 + 2
+                        }
+                      )
+)

--- a/tests/testthat/Testbox/tests/testthat/test-moduleR6.R
+++ b/tests/testthat/Testbox/tests/testthat/test-moduleR6.R
@@ -1,0 +1,21 @@
+box::use(
+  testthat[test_that, expect_equal, expect_s3_class]
+)
+
+box::use(
+  app/modules/moduleR6
+)
+
+test_that("TestR6 class can be instantiated", {
+  t1 <- moduleR6$TestR6$new() # nolint
+
+  expect_s3_class(t1, "R6")
+  expect_s3_class(t1, "TestR6")
+  })
+
+test_that("TestR6 Methods can be evaluated", {
+  t1 <- moduleR6$TestR6$new() # nolint
+
+  expect_equal(t1$show(), 4)
+  expect_equal(print(t1$print2()), 3)
+})


### PR DESCRIPTION
Issue #6

## Changes description

Add support for R6 classes attached as box modules.

## How to test

* Unit tests provided
* To use with a rhino app, covr::file_coverage(source_files = "app/main.R", test_files = list.files("test/testthat", full.names = TRUE))
* To get the GUI report, covr::report(covr::file_coverage(source_files = "app/main.R", test_files = list.files("tests/testthat", full.names = TRUE)))

Screenshot showing `covr` counting through an R6 class:

![Screen Shot 2023-01-20 at 4 23 59 PM](https://user-images.githubusercontent.com/1477968/213649671-7462ce6c-2a2c-45e5-95b9-094a478053ce.png)
