### PR TITLE
Tests for box module attached functions, three dots, aliases

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Encoding: UTF-8
 Package: covr
 Title: Test Coverage for Packages
-Version: 3.6.0.9003
+Version: 3.6.0.9004
 Authors@R: c(
     person("Jim", "Hester", email = "james.f.hester@gmail.com", role = c("aut", "cre")),
     person("Willem", "Ligtenberg", role = "ctb"),

--- a/tests/testthat/Testbox_attached_modules_functions/app/app.R
+++ b/tests/testthat/Testbox_attached_modules_functions/app/app.R
@@ -1,0 +1,7 @@
+options(box.path = file.path(getwd()))
+rm(list = ls(box:::loaded_mods), envir = box:::loaded_mods)
+
+box::use(
+  app/modules/module,
+  app/modules/moduleR6
+)

--- a/tests/testthat/Testbox_attached_modules_functions/app/modules/module.R
+++ b/tests/testthat/Testbox_attached_modules_functions/app/modules/module.R
@@ -1,0 +1,19 @@
+#' an example function
+#'
+#' @export
+a <- function(x) {
+  if (x <= 1) {
+    1
+  } else {
+    2
+  }
+}
+
+#' @export
+b <- function(x) {
+  return(x * 2)
+}
+
+private_function <- function(x) {
+  x ^ 2
+}

--- a/tests/testthat/Testbox_attached_modules_functions/app/modules/moduleR6.R
+++ b/tests/testthat/Testbox_attached_modules_functions/app/modules/moduleR6.R
@@ -1,0 +1,11 @@
+#' @export
+TestR6 <- R6::R6Class("TestR6", # nolint
+                      public = list(
+                        show = function(x) {
+                          1 + 3
+                        },
+                        print2 = function(x) {
+                          1 + 2
+                        }
+                      )
+)

--- a/tests/testthat/Testbox_attached_modules_functions/tests/testthat.R
+++ b/tests/testthat/Testbox_attached_modules_functions/tests/testthat.R
@@ -1,0 +1,6 @@
+options(box.path = file.path(getwd()))
+rm(list = ls(box:::loaded_mods), envir = box:::loaded_mods)
+
+library(testthat)
+
+test_dir("tests/testthat")

--- a/tests/testthat/Testbox_attached_modules_functions/tests/testthat/test-aliased_functions.R
+++ b/tests/testthat/Testbox_attached_modules_functions/tests/testthat/test-aliased_functions.R
@@ -1,0 +1,15 @@
+box::use(
+  testthat[test_that, expect_equal]
+)
+
+box::use(
+  app/modules/module[x = a]
+)
+
+test_that("attached regular function `a` works as expected", {
+  expect_equal(x(1), 1)
+  expect_equal(x(2), 2)
+  expect_equal(x(3), 2)
+  expect_equal(x(4), 2)
+  expect_equal(x(0), 1)
+})

--- a/tests/testthat/Testbox_attached_modules_functions/tests/testthat/test-aliased_modules.R
+++ b/tests/testthat/Testbox_attached_modules_functions/tests/testthat/test-aliased_modules.R
@@ -1,0 +1,15 @@
+box::use(
+  testthat[test_that, expect_equal]
+)
+
+box::use(
+  x = app/modules/module
+)
+
+test_that("attached regular function `a` works as expected", {
+  expect_equal(x$a(1), 1)
+  expect_equal(x$a(2), 2)
+  expect_equal(x$a(3), 2)
+  expect_equal(x$a(4), 2)
+  expect_equal(x$a(0), 1)
+})

--- a/tests/testthat/Testbox_attached_modules_functions/tests/testthat/test-attached_R6.R
+++ b/tests/testthat/Testbox_attached_modules_functions/tests/testthat/test-attached_R6.R
@@ -1,0 +1,21 @@
+box::use(
+  testthat[test_that, expect_equal, expect_s3_class]
+)
+
+box::use(
+  app/modules/moduleR6[TestR6]
+)
+
+test_that("TestR6 class can be instantiated", {
+  t1 <- TestR6$new() # nolint
+
+  expect_s3_class(t1, "R6")
+  expect_s3_class(t1, "TestR6")
+})
+
+test_that("TestR6 Methods can be evaluated", {
+  t1 <- TestR6$new() # nolint
+
+  expect_equal(t1$show(), 4)
+  expect_equal(t1$print2(), 3)
+})

--- a/tests/testthat/Testbox_attached_modules_functions/tests/testthat/test-attached_functions.R
+++ b/tests/testthat/Testbox_attached_modules_functions/tests/testthat/test-attached_functions.R
@@ -1,0 +1,15 @@
+box::use(
+  testthat[test_that, expect_equal]
+)
+
+box::use(
+  app/modules/module[a]
+)
+
+test_that("attached regular function `a` works as expected", {
+  expect_equal(a(1), 1)
+  expect_equal(a(2), 2)
+  expect_equal(a(3), 2)
+  expect_equal(a(4), 2)
+  expect_equal(a(0), 1)
+})

--- a/tests/testthat/Testbox_attached_modules_functions/tests/testthat/test-three_dots.R
+++ b/tests/testthat/Testbox_attached_modules_functions/tests/testthat/test-three_dots.R
@@ -1,0 +1,21 @@
+box::use(
+  testthat[test_that, expect_equal]
+)
+
+box::use(
+  app/modules/module[...]
+)
+
+test_that("attached regular function `a` works as expected", {
+  expect_equal(a(1), 1)
+  expect_equal(a(2), 2)
+  expect_equal(a(3), 2)
+  expect_equal(a(4), 2)
+  expect_equal(a(0), 1)
+})
+
+test_that("attached regular function `b` works as expected", {
+  expect_equal(b(1), 2)
+  expect_equal(b(2), 4)
+  expect_equal(b(3), 6)
+})

--- a/tests/testthat/test-box_attached_modules_functions.R
+++ b/tests/testthat/test-box_attached_modules_functions.R
@@ -1,0 +1,17 @@
+context("box-attached-modules-functions")
+
+test_that("box module coverage is reported", {
+  withr::with_dir("Testbox_attached_modules_functions", {
+    cov <- as.data.frame(file_coverage(
+      source_files = "app/app.R",
+      test_files = list.files("tests/testthat", full.names = TRUE)))
+
+    expect_equal(cov$value, c(20, 8, 12, 3, 0, 1, 1))
+    expect_equal(cov$first_line, c(5, 6, 8, 14, 18, 5, 8))
+    expect_equal(cov$last_line, c(5, 6, 8, 14, 18, 5, 8))
+    expect_true("a" %in% cov$functions)
+    expect_true("private_function" %in% cov$functions)
+    expect_true("show" %in% cov$functions)
+  })
+
+})


### PR DESCRIPTION
## Changes description

No new code to support `klmr/box` attached functions, three dots, aliases.

Just tests for the above.

Closes #3 #5 #10

## How to test

* Unit tests provided
* To use with a `rhino` app, `covr::file_coverage(source_files = "box_loader.R", test_files = list.files("test/testthat", full.names = TRUE))` where `box_loader.R` contains `box::use( # all of your app's modules )`
* To get the GUI report, wrap the above with `covr::report()`
