### PR TITLE
Feature/code cleanup

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Encoding: UTF-8
 Package: covr
 Title: Test Coverage for Packages
-Version: 3.6.0.9004
+Version: 3.6.0.9005
 Authors@R: c(
     person("Jim", "Hester", email = "james.f.hester@gmail.com", role = c("aut", "cre")),
     person("Willem", "Ligtenberg", role = "ctb"),

--- a/R/R6.R
+++ b/R/R6.R
@@ -2,18 +2,22 @@ replacements_R6 <- function(env) {
   unlist(recursive = FALSE, eapply(env, all.names = TRUE,
     function(obj) {
       if (inherits(obj, "R6ClassGenerator")) {
-        unlist(recursive = FALSE, eapply(obj,
-          function(o) {
-            if (inherits(o, "list")) {
-              lapply(names(o),
-                  function(f_name) {
-                  f <- get(f_name, o)
-                  if (inherits(f, "function")) {
-                    replacement(f_name, env = env, target_value = f)
-                  }
-})
+        traverse_R6(obj, env)
       }
     }))
 }
-    }))
+
+traverse_R6 <- function(obj, env) {
+    unlist(recursive = FALSE, eapply(obj,
+       function(o) {
+         if (inherits(o, "list")) {
+           lapply(names(o),
+                  function(f_name) {
+                    f <- get(f_name, o)
+                    if (inherits(f, "function")) {
+                      replacement(f_name, env = env, target_value = f)
+                    }
+                  })
+         }
+       }))
 }

--- a/R/box.R
+++ b/R/box.R
@@ -1,7 +1,7 @@
-replacements_box <- function(env) {
+replacements_box_modules <- function(env) {
   unlist(recursive = FALSE, eapply(env, all.names = TRUE,
       function(obj) {
-       if (inherits(obj, "box$mod")) {
+        if (inherits(attr(obj, "spec"), "box$mod_spec")) {
          obj_impl <- attr(obj, "namespace")
          lapply(ls(obj_impl),
             function(f_name) {
@@ -9,6 +9,10 @@ replacements_box <- function(env) {
               if (inherits(f, "function")) {
                 replacement(f_name, env = obj, target_value = f)
               }
+              # This else if looks like it should work, but it doesn't
+              # else if (inherits(f, "R6ClassGenerator")) {
+              #   traverse_R6(f, obj)
+              # }
             }
           )
         }
@@ -20,33 +24,44 @@ replacements_box <- function(env) {
 replacements_box_r6 <- function(env) {
   unlist(recursive = FALSE, eapply(env, all.names = TRUE,
       function(obj) {
-        if (inherits(obj, "box$mod")) {
+        if (inherits(attr(obj, "spec"), "box$mod_spec")) {
           obj_impl <- attr(obj, "namespace")
           unlist(recursive = FALSE, lapply(ls(obj_impl),
               function(f_name) {
                 f <- get(f_name, obj_impl)
                 if (inherits(f, "R6ClassGenerator")) {
-                  unlist(recursive = FALSE, eapply(f, all.names = TRUE,
-                      function(o) {
-                        if (inherits(o, "list")) {
-                          lapply(names(o),
-                            function(m_name) {
-                              m <- get(m_name, o)
-                              if (inherits(m, "function")) {
-                                replacement(m_name, env = obj, target_value = m)
-                              }
-                            }
-                          )
-                        }
-                      }
-                    )
-                  )
+                  traverse_R6(f, obj)
                 }
+                # keeping this here for notes
+                # if (inherits(f, "R6ClassGenerator")) {
+                #   unlist(recursive = FALSE, eapply(f, all.names = TRUE,
+                #       function(o) {
+                #         if (inherits(o, "list")) {
+                #           lapply(names(o),
+                #             function(m_name) {
+                #               m <- get(m_name, o)
+                #               if (inherits(m, "function")) {
+                #                 replacement(m_name, env = obj, target_value = m)
+                #               }
+                #             }
+                #           )
+                #         }
+                #       }
+                #     )
+                #   )
+                # }
               }
             )
           )
         }
       }
     )
+  )
+}
+
+replacements_box <- function(env) {
+  c(
+    replacements_box_modules(env),
+    replacements_box_r6(env)
   )
 }

--- a/R/box.R
+++ b/R/box.R
@@ -1,67 +1,30 @@
-replacements_box_modules <- function(env) {
+replacements_box <- function(env) {
   unlist(recursive = FALSE, eapply(env, all.names = TRUE,
       function(obj) {
         if (inherits(attr(obj, "spec"), "box$mod_spec")) {
           obj_impl <- attr(obj, "namespace")
-          lapply(ls(obj_impl),
-            function(f_name) {
-              f <- get(f_name, obj_impl)
-              if (inherits(f, "function")) {
-                replacement(f_name, env = obj, target_value = f)
-              }
-              # This else if looks like it should work, but it doesn't
-              # else if (inherits(f, "R6ClassGenerator")) {
-              #   traverse_R6(f, obj)
-              # }
-            }
-          )
-        }
-      }
-    )
-  )
-}
-
-replacements_box_r6 <- function(env) {
-  unlist(recursive = FALSE, eapply(env, all.names = TRUE,
-      function(obj) {
-        if (inherits(attr(obj, "spec"), "box$mod_spec")) {
-          obj_impl <- attr(obj, "namespace")
-          unlist(recursive = FALSE, lapply(ls(obj_impl),
+          compact(c(
+            lapply(ls(obj_impl),
               function(f_name) {
                 f <- get(f_name, obj_impl)
-                if (inherits(f, "R6ClassGenerator")) {
-                  traverse_R6(f, obj)
+                if (inherits(f, "function")) {
+                  replacement(f_name, env = obj, target_value = f)
                 }
-                # keeping this here for notes
-                # if (inherits(f, "R6ClassGenerator")) {
-                #   unlist(recursive = FALSE, eapply(f, all.names = TRUE,
-                #       function(o) {
-                #         if (inherits(o, "list")) {
-                #           lapply(names(o),
-                #             function(m_name) {
-                #               m <- get(m_name, o)
-                #               if (inherits(m, "function")) {
-                #                 replacement(m_name, env = obj, target_value = m)
-                #               }
-                #             }
-                #           )
-                #         }
-                #       }
-                #     )
-                #   )
-                # }
               }
+            ),
+            unlist(recursive = FALSE,
+              lapply(ls(obj_impl),
+                function(f_name) {
+                  f <- get(f_name, obj_impl)
+                  if (inherits(f, "R6ClassGenerator")) {
+                    traverse_R6(f, obj)
+                  }
+                }
+              )
             )
-          )
+          ))
         }
       }
     )
-  )
-}
-
-replacements_box <- function(env) {
-  c(
-    replacements_box_modules(env),
-    replacements_box_r6(env)
   )
 }

--- a/R/box.R
+++ b/R/box.R
@@ -2,8 +2,8 @@ replacements_box_modules <- function(env) {
   unlist(recursive = FALSE, eapply(env, all.names = TRUE,
       function(obj) {
         if (inherits(attr(obj, "spec"), "box$mod_spec")) {
-         obj_impl <- attr(obj, "namespace")
-         lapply(ls(obj_impl),
+          obj_impl <- attr(obj, "namespace")
+          lapply(ls(obj_impl),
             function(f_name) {
               f <- get(f_name, obj_impl)
               if (inherits(f, "function")) {

--- a/R/box.R
+++ b/R/box.R
@@ -3,26 +3,28 @@ replacements_box <- function(env) {
       function(obj) {
         if (inherits(attr(obj, "spec"), "box$mod_spec")) {
           obj_impl <- attr(obj, "namespace")
-          compact(c(
-            lapply(ls(obj_impl),
-              function(f_name) {
-                f <- get(f_name, obj_impl)
-                if (inherits(f, "function")) {
-                  replacement(f_name, env = obj, target_value = f)
-                }
-              }
-            ),
-            unlist(recursive = FALSE,
+          compact(
+            c(
               lapply(ls(obj_impl),
                 function(f_name) {
                   f <- get(f_name, obj_impl)
-                  if (inherits(f, "R6ClassGenerator")) {
-                    traverse_R6(f, obj)
+                  if (inherits(f, "function")) {
+                    replacement(f_name, env = obj, target_value = f)
                   }
                 }
+              ),
+              unlist(recursive = FALSE,
+                lapply(ls(obj_impl),
+                  function(f_name) {
+                    f <- get(f_name, obj_impl)
+                    if (inherits(f, "R6ClassGenerator")) {
+                      traverse_R6(f, obj)
+                    }
+                  }
+                )
               )
             )
-          ))
+          )
         }
       }
     )

--- a/R/covr.R
+++ b/R/covr.R
@@ -94,7 +94,6 @@ trace_environment <- function(env) {
       replacements_RC(env),
       replacements_R6(env),
       replacements_box(env),
-      replacements_box_r6(env),
       lapply(ls(env, all.names = TRUE), replacement, env = env)))
 
   lapply(the$replacements, replace)


### PR DESCRIPTION
Closes #15 

## Changes description

FInally broke the `unlist()` puzzle. Just one function to handle both box module functions and R6 classes.

Unit tests should still pass. There should not be any changes in behavior.